### PR TITLE
fix: support gradle 8

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/hypertrace/gradle/jacoco/JacocoReportPlugin.java
+++ b/src/main/java/org/hypertrace/gradle/jacoco/JacocoReportPlugin.java
@@ -57,7 +57,7 @@ public class JacocoReportPlugin implements Plugin<Project> {
   }
 
   private void configureExistingReport(JacocoReport reportTask, Test testTask) {
-    reportTask.getReports().getXml().setEnabled(true);
+    reportTask.getReports().getXml().getRequired().set(true);
     reportTask.dependsOn(testTask);
   }
 


### PR DESCRIPTION
## Description
Gradle 7 deprecated and 8 removed the enabled attribute on reports, in favor of the required property ( https://docs.gradle.org/current/userguide/upgrading_version_7.html#report_and_testreport_api_cleanup ) Switching over removes support from gradle < 6.1, but adds support for gradle 8+


### Testing
Verified in gradle 7 and 8.
